### PR TITLE
feat: Notification Center Modal & Real-Time Sync

### DIFF
--- a/src/components/NotificationBell/NotificationBell.tsx
+++ b/src/components/NotificationBell/NotificationBell.tsx
@@ -1,11 +1,12 @@
+import { useNavigate } from '@tanstack/react-router'
 import { useNotifications } from '../../hooks/useNotifications'
 
 interface NotificationBellProps {
-  onClick: () => void
   className?: string
 }
 
-export function NotificationBell({ onClick, className = '' }: NotificationBellProps) {
+export function NotificationBell({ className = '' }: NotificationBellProps) {
+  const navigate = useNavigate()
   const { unreadCount } = useNotifications()
 
   // Format badge text: show "99+" when count exceeds 99
@@ -19,9 +20,13 @@ export function NotificationBell({ onClick, className = '' }: NotificationBellPr
         ? '1 unread notification'
         : `${unreadCount} unread notifications`
 
+  const handleClick = () => {
+    navigate({ to: '/notifications' })
+  }
+
   return (
     <button
-      onClick={onClick}
+      onClick={handleClick}
       className={`relative p-2 hover:bg-slate-100 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${className}`}
       aria-label={ariaLabel}
     >

--- a/src/routes/notifications.tsx
+++ b/src/routes/notifications.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { NotificationCenterModal } from '../components/NotificationCenter'
+
+/* eslint-disable react-refresh/only-export-components */
+function NotificationsRoute() {
+  return (
+    <NotificationCenterModal
+      isOpen={true}
+      onClose={() => {
+        window.history.back()
+      }}
+    />
+  )
+}
+
+export const Route = createFileRoute('/notifications')({
+  component: NotificationsRoute,
+})


### PR DESCRIPTION
Implements Linear FAB-219: Notification Center Modal & Real-Time Sync

## Summary
Creates a polished modal UI for viewing and managing notifications via TanStack Router, leveraging the existing data layer from FAB-179 and FAB-188.

## Implementation Details

### New Files
- `src/routes/notifications.tsx` - Modal route that opens NotificationCenterModal component
  - Uses TanStack Router pattern for modal routes
  - Proper onClose handler using window.history.back()
  - Passes isOpen={true} to control modal visibility

### Modified Files
- `src/components/NotificationBell/NotificationBell.tsx` 
  - Changed from accepting onClick callback to internally using useNavigate()
  - Navigates to /notifications route when clicked
  - Cleaner integration with TanStack Router

### Existing Components Utilized
- `NotificationCenterModal` - Already fully implemented with all required features:
  - Scrollable list of notifications
  - Mark-as-read per notification with optimistic updates
  - Mark-all-as-read bulk action button
  - Empty state display
  - Keyboard navigation (Escape to close, arrow keys to navigate)
  - ARIA labels and focus trap for accessibility
  - Real-time unread count badge
  - Filter toggle (All / Unread)
  - Dismiss button for each notification

## Acceptance Criteria ✅
- [x] Modal component opens via TanStack Router (modal route pattern)
- [x] Integrates with existing useNotifications hook (30s polling inherited)
- [x] Displays notifications in scrollable list
- [x] Mark-as-read action per notification with optimistic update
- [x] Mark-all-as-read bulk action button
- [x] Empty state when no notifications exist
- [x] Keyboard navigation and ARIA labels (focus trap, Escape to close)
- [x] Unread count badge reflected in real time

## Testing
- NotificationBell now navigates to /notifications route
- Modal can be closed with Escape key or back button
- All existing notification features work seamlessly

## Related Issues
- Depends on FAB-179 (useNotifications hook)
- Depends on FAB-188 (useNotificationPreferences hook)
- Part of FAB-218 (Notification system sprint)