### PR TITLE
NotificationBell Component with Unread Badge (FAB-234)

### DIFF
--- a/src/components/NotificationBell/NotificationBell.tsx
+++ b/src/components/NotificationBell/NotificationBell.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState } from 'react'
-import { useNotifications } from '../../hooks/useNotifications'
-import { useNotificationCenter } from '../../hooks/useNotificationCenter'
+import { useNotificationCenter as useNotificationCenterHook } from '../../hooks/useNotificationCenter'
+import { useNotificationCenter } from '../../contexts/NotificationCenterProvider'
 
 /**
  * NotificationBell Component
@@ -17,7 +17,7 @@ import { useNotificationCenter } from '../../hooks/useNotificationCenter'
  * - Smooth CSS transitions when count changes
  */
 export function NotificationBell() {
-  const { unreadCount } = useNotifications()
+  const { unreadCount } = useNotificationCenterHook()
   const { isPanelOpen, togglePanel } = useNotificationCenter()
   const buttonRef = useRef<HTMLButtonElement>(null)
   const [prevCount, setPrevCount] = useState(unreadCount)
@@ -54,7 +54,7 @@ export function NotificationBell() {
           : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800'
       }`}
       aria-label={ariaLabel}
-      aria-pressed={isPanelOpen}
+      aria-expanded={isPanelOpen}
     >
       {/* Bell icon */}
       <svg


### PR DESCRIPTION
Implements Linear FAB-234

## Summary
This PR refines the NotificationBell component to ensure it meets all FAB-234 acceptance criteria.

## Changes
- **useNotificationCenter Hook**: Updated component to use the  hook from FAB-231 for unread count, providing additional features like badge capping and grouping utilities
- **Accessibility**: Changed  to  for proper semantic accessibility

## Acceptance Criteria Status
- ✅ NotificationBell component in src/components/NotificationBell/
- ✅ Bell icon using SVG
- ✅ Unread badge rounded pill, hidden when count is 0
- ✅ Badge animates (pulse/bounce) on new notifications
- ✅ Badge capped at "99+" for large counts
- ✅ Click toggles NotificationDrawer (NotificationCenterModal) open/closed
- ✅ Active/open state visually distinguished
- ✅ Accessible: aria-label="Notifications, X unread", aria-expanded state, keyboard activatable
- ✅ Consumes useNotificationCenter() for unread count (FAB-231)
- ✅ Placed in app header/layout

## Related Issues
- FAB-234: NotificationBell Component with Unread Badge
- FAB-231: useNotificationCenter() hook
- FAB-233: NotificationDrawer (NotificationCenterModal)